### PR TITLE
Typo

### DIFF
--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -521,12 +521,12 @@ def test_process_cache():
             process_cache(cache, kernel_options, tuning_options, runner)
             assert "kernel" in str(excep.value)
 
-        with pytest.raises(ValueError) as excp:
+        with pytest.raises(ValueError) as excep:
             runner.dev.name = "wrong_device"
             process_cache(cache, kernel_options, tuning_options, runner)
             assert "device" in str(excep.value)
 
-        with pytest.raises(ValueError) as excp:
+        with pytest.raises(ValueError) as excep:
             tuning_options.tune_params["y"] = ["a", "b"]
             process_cache(cache, kernel_options, tuning_options, runner)
             assert "parameter" in str(excep.value)


### PR DESCRIPTION
There was a typo in the code, so the test would fail.