### PR TITLE
Error message fix

### DIFF
--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -234,7 +234,7 @@ class CupyFunctions:
             device texture memory. See tune_kernel().
         :type texmem_args: dict
         """
-        raise NotImplementedError('CuPy backend does not yet support constant memory')
+        raise NotImplementedError('CuPy backend does not yet support texture memory')
 
     def run_kernel(self, func, gpu_args, threads, grid, stream=None):
         """runs the CUDA kernel passed as 'func'


### PR DESCRIPTION
The error message said "constant" when it should have said "texture". Also, should logging be happening or not? It does for constant but not for texture.