### PR TITLE
Support boolean datatype in PyCUDA backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support for locked clocks in NVMLObserver
 - Support for measuring core voltages using NVML
 - Support for custom preprocessor definitions
+- Support for boolean scalar arguments in PyCUDA backend
 
 ### Changed
 - Migrated from github.com/benvanwerkhoven to github.com/KernelTuner

--- a/kernel_tuner/pycuda.py
+++ b/kernel_tuner/pycuda.py
@@ -188,6 +188,8 @@ class PyCudaFunctions(object):
                     gpu_args.append(Holder(arg))
                 else:
                     gpu_args.append(Holder(arg.cuda()))
+            elif isinstance(arg, np.bool_):  # pycuda does not support bool, convert to uint8 instead
+                gpu_args.append(arg.astype(np.uint8))
             else:    # if not an array, just pass argument along
                 gpu_args.append(arg)
         return gpu_args

--- a/kernel_tuner/pycuda.py
+++ b/kernel_tuner/pycuda.py
@@ -188,7 +188,8 @@ class PyCudaFunctions(object):
                     gpu_args.append(Holder(arg))
                 else:
                     gpu_args.append(Holder(arg.cuda()))
-            elif isinstance(arg, np.bool_):  # pycuda does not support bool, convert to uint8 instead
+            # pycuda does not support bool, convert to uint8 instead
+            elif isinstance(arg, np.bool_):
                 gpu_args.append(arg.astype(np.uint8))
             else:    # if not an array, just pass argument along
                 gpu_args.append(arg)

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -60,6 +60,7 @@ default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 def check_argument_type(dtype, kernel_argument):
     """check if the numpy.dtype matches the type used in the code"""
     types_map = {
+        "bool": ["bool"],
         "uint8": ["uchar", "unsigned char", "uint8_t"],
         "int8": ["char", "int8_t"],
         "uint16": ["ushort", "unsigned short", "uint16_t"],

--- a/test/test_pycuda_functions.py
+++ b/test/test_pycuda_functions.py
@@ -17,9 +17,10 @@ def test_ready_argument_list():
     size = 1000
     a = np.int32(75)
     b = np.random.randn(size).astype(np.float32)
-    c = np.zeros_like(b)
+    c = np.bool_(True)
+    d = np.zeros_like(b)
 
-    arguments = [c, a, b]
+    arguments = [d, a, b, c]
 
     dev = kt_pycuda.PyCudaFunctions(0)
     gpu_args = dev.ready_argument_list(arguments)
@@ -27,6 +28,7 @@ def test_ready_argument_list():
     assert isinstance(gpu_args[0], pycuda.driver.DeviceAllocation)
     assert isinstance(gpu_args[1], np.int32)
     assert isinstance(gpu_args[2], pycuda.driver.DeviceAllocation)
+    assert isinstance(gpu_args[3], np.uint8)
 
 
 @skip_if_no_pycuda


### PR DESCRIPTION
PyCUDA is the only CUDA backend that does not support the `np.bool_` data type (as a scalar, arrays are fine). This PR changes scalar booleans to `np.uint8` in the PyCUDA backend to fix this.
OpenCL kernels don't support boolean arguments at all, so no attempt is made to handle those.

We also get rid of the "bool does not match bool value." warning emitted by KernelTuner when an argument is a boolean.

