### PR TITLE
Change error message

### DIFF
--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -55,7 +55,7 @@ class CupyFunctions:
         self.texrefs = []
         if not cp:
             raise ImportError("Error: cupy not installed, please install e.g. " +
-                            "using 'pip install cupy-cuda111', please check https://github.com/cupy/cupy.")
+                            "using 'pip install cupy', please check https://github.com/cupy/cupy.")
 
         #select device
         self.dev = dev = cp.cuda.Device(device)


### PR DESCRIPTION
The error message refers to `cupy-cuda111` and create confusion in users. Better to use the generic `cupy` package in this message.