### PR TITLE
fix restricted/invalid configs being counted as fevals

### DIFF
--- a/kernel_tuner/strategies/common.py
+++ b/kernel_tuner/strategies/common.py
@@ -94,23 +94,24 @@ class CostFunc:
                 result = params_dict
                 result[self.tuning_options.objective] = util.InvalidConfig()
 
-        # compile and benchmark this instance
-        if not result:
+        if legal:
+            # compile and benchmark this instance
             res = self.runner.run([params], self.tuning_options)
             result = res[0]
 
-        # append to tuning results
-        if x_int not in self.tuning_options.unique_results:
-            self.tuning_options.unique_results[x_int] = result
+            # append to tuning results
+            if x_int not in self.tuning_options.unique_results:
+                self.tuning_options.unique_results[x_int] = result
 
-        self.results.append(result)
+            self.results.append(result)
+
+            # upon returning from this function control will be given back to the strategy, so reset the start time
+            self.runner.last_strategy_start_time = perf_counter()
 
         # get numerical return value, taking optimization direction into account
         return_value = result[self.tuning_options.objective] or sys.float_info.max
         return_value = return_value if not self.tuning_options.objective_higher_is_better else -return_value
 
-        # upon returning from this function control will be given back to the strategy, so reset the start time
-        self.runner.last_strategy_start_time = perf_counter()
         return return_value
 
     def get_bounds_x0_eps(self):


### PR DESCRIPTION
This pull request presents a minor but possibly impactful change. Due to some of my own refactoring in the fall last year configurations that are attempted by an optimization strategy that did not pass the restrictions could be counted as function evaluations (by being added to unique_results) and were actually returned among the results returned by tune_kernel(). This was not intentional and is fixed by the changes in this pull request.
