### PR TITLE
Read instant power in pwr_usage

### DIFF
--- a/kernel_tuner/observers/nvml.py
+++ b/kernel_tuner/observers/nvml.py
@@ -298,7 +298,8 @@ class nvml:
 
     def pwr_usage(self):
         """Return current power usage in milliwatts."""
-        return pynvml.nvmlDeviceGetPowerUsage(self.dev)
+        NVML_FI_DEV_POWER_INSTANT = 186
+        return pynvml.nvmlDeviceGetFieldValues(self.dev, [NVML_FI_DEV_POWER_INSTANT])[0].value.uiVal
 
     def gr_voltage(self):
         """Return current graphics voltage in millivolts."""


### PR DESCRIPTION
The original code uses `pynvml.nvmlDeviceGetPowerUsage` to query the power consumption of the GPU, but this is an averaged value and therefore less precise. While it is still possible to measure power somewhat reliable using this method, one needs to run the measurement for a sufficiently long time to let the value stabilize.

NVML also has the more low-level `nvmlDeviceGetFieldValues` function available that also exposes a field with instantaneous power use. This metric is to be preferred over the average power consumption.

Pynvml does not wrap this function nicely, thus the appropriate enum item is explicitly added to the code. The interface can return values in different formats, thus the return value also needs to be cast to the appropriate format.

The MR in its current form is quite simple, as it just replaces the existing functionality. We could also opt for some configurability, e.g. also allow `NVML_FI_DEV_POWER_AVERAGE=185` (same as  `nvmlDeviceGetPowerUsage`). Moreover, note that the `scopeId` is handled internally by pynvml, see [here](https://github.com/gpuopenanalytics/pynvml/blob/43a7803c42358a87e765bb66373f3ae536d589a3/pynvml/nvml.py#L3216).  We typically are interested in `scopeId=0` anyway, which on all current GPUs denotes the power consumption of the GPU alone.