### PR TITLE
Catch RuntimeError when importing from pyhip

### DIFF
--- a/kernel_tuner/backends/hip.py
+++ b/kernel_tuner/backends/hip.py
@@ -11,7 +11,7 @@ from kernel_tuner.observers.hip import HipRuntimeObserver
 
 try:
     from pyhip import hip, hiprtc
-except ImportError:
+except (ImportError, RuntimeError):
     hip = None
     hiprtc = None
 

--- a/kernel_tuner/observers/hip.py
+++ b/kernel_tuner/observers/hip.py
@@ -4,7 +4,7 @@ from kernel_tuner.observers.observer import BenchmarkObserver
 
 try:
     from pyhip import hip, hiprtc
-except ImportError:
+except (ImportError, RuntimeError):
     hip = None
     hiprtc = None
 


### PR DESCRIPTION
If pyhip is installed but ROCm is not available/loaded (e.g. on the DAS-6 headnode), importing pyhip fails with a `RuntimeError` instead of `ImportError`. This makes KernelTuner crash completely instead of just HIP being unavailable. I've changed the hip backend and observer to catch the `RuntimeError` as well to fix this.