### PR TITLE
Update PMTObserver for latest PMT changes

### DIFF
--- a/examples/cuda/vector_add_observers_pmt.py
+++ b/examples/cuda/vector_add_observers_pmt.py
@@ -31,7 +31,7 @@ def tune():
     tune_params = dict()
     tune_params["block_size_x"] = [128+64*i for i in range(15)]
 
-    pmtobserver = PMTObserver(["nvidia", "rapl"])
+    pmtobserver = PMTObserver([("nvidia", 0), "rapl"])
 
     metrics = OrderedDict()
     metrics["GPU W"] = lambda p: p["nvidia_power"]

--- a/examples/cuda/vector_add_observers_pmt.py
+++ b/examples/cuda/vector_add_observers_pmt.py
@@ -31,10 +31,10 @@ def tune():
     tune_params = dict()
     tune_params["block_size_x"] = [128+64*i for i in range(15)]
 
-    pmtobserver = PMTObserver(["nvml", "rapl"])
+    pmtobserver = PMTObserver(["nvidia", "rapl"])
 
     metrics = OrderedDict()
-    metrics["GPU W"] = lambda p: p["nvml_power"]
+    metrics["GPU W"] = lambda p: p["nvidia_power"]
     metrics["CPU W"] = lambda p: p["rapl_power"]
 
     results, env = tune_kernel("vector_add", kernel_string, size, args, tune_params, observers=[pmtobserver], metrics=metrics, iterations=32)

--- a/kernel_tuner/observers/pmt.py
+++ b/kernel_tuner/observers/pmt.py
@@ -43,7 +43,7 @@ class PMTObserver(BenchmarkObserver):
         else:
             # User specifices a string (single platform) as observable
             observable = {observable: None}
-        supported = ["arduino", "jetson", "likwid", "nvml", "rapl", "rocm", "xilinx"]
+        supported = ["powersensor2", "powersensor3", "nvidia", "likwid", "rapl", "rocm", "xilinx"]
         for obs in observable.keys():
             if not obs in supported:
                 raise ValueError(f"Observable {obs} not in supported: {supported}")
@@ -70,8 +70,9 @@ class PMTObserver(BenchmarkObserver):
         for i in range(len(self.pms)):
             begin_state = self.begin_states[i]
             end_state = end_states[i]
-            measured_energy = pmt.joules(begin_state, end_state)
-            measured_power = pmt.watts(begin_state, end_state)
+            measured_energy = pmt.pypmt.PMT.joules(begin_state, end_state)
+            measured_power = pmt.pypmt.PMT.watts(begin_state, end_state)
+            print(measured_energy, measured_power)
             pm_name = self.pm_names[i]
             energy_result_name = f"{pm_name}_energy"
             power_result_name = f"{pm_name}_power"

--- a/kernel_tuner/observers/pmt.py
+++ b/kernel_tuner/observers/pmt.py
@@ -48,7 +48,7 @@ class PMTObserver(BenchmarkObserver):
             if not obs in supported:
                 raise ValueError(f"Observable {obs} not in supported: {supported}")
 
-        self.pms = [pmt.get_pmt(obs[0], obs[1]) for obs in observable.items()]
+        self.pms = [pmt.create(obs[0], obs[1]) for obs in observable.items()]
         self.pm_names = list(observable.keys())
 
         self.begin_states = [None] * len(self.pms)
@@ -70,9 +70,8 @@ class PMTObserver(BenchmarkObserver):
         for i in range(len(self.pms)):
             begin_state = self.begin_states[i]
             end_state = end_states[i]
-            measured_energy = pmt.pypmt.PMT.joules(begin_state, end_state)
-            measured_power = pmt.pypmt.PMT.watts(begin_state, end_state)
-            print(measured_energy, measured_power)
+            measured_energy = pmt.joules(begin_state, end_state)
+            measured_power = pmt.watts(begin_state, end_state)
             pm_name = self.pm_names[i]
             energy_result_name = f"{pm_name}_energy"
             power_result_name = f"{pm_name}_power"

--- a/kernel_tuner/observers/pmt.py
+++ b/kernel_tuner/observers/pmt.py
@@ -38,8 +38,8 @@ class PMTObserver(BenchmarkObserver):
         if type(observable) is dict:
             pass
         elif type(observable) is list:
-            # user specifies a list of platforms as observable
-            observable = dict([(obs, 0) for obs in observable])
+            # user specifies a list of platforms as observable, optionally with an argument
+            observable = dict([obs if isinstance(obs, tuple) else (obs, None) for obs in observable])
         else:
             # User specifices a string (single platform) as observable
             observable = {observable: None}


### PR DESCRIPTION
The Python interface of PMT has changed, the `PMTObserver` has been updated accordingly. The new `nvidia` backend is used instead of `nvml`.