### PR TITLE
Add support for float16 to HIP backend

### DIFF
--- a/kernel_tuner/backends/hip.py
+++ b/kernel_tuner/backends/hip.py
@@ -19,6 +19,7 @@ dtype_map = {
     "bool": ctypes.c_bool,
     "int8": ctypes.c_int8,
     "int16": ctypes.c_int16,
+    "float16": ctypes.c_int16,
     "int32": ctypes.c_int32,
     "int64": ctypes.c_int64,
     "uint8": ctypes.c_uint8,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
     "Willem-Jan Palenstijn <w.j.palenstijn@liacs.leidenuniv.nl>",
     "Bram Veenboer <veenboer@astron.nl>",
     "Richard Schoonhoven <Richard.Schoonhoven@cwi.nl>",
+    "Leon Oostrum <l.oostrum@esciencecenter.nl",
 ]
 
 readme = "README.md"


### PR DESCRIPTION
The HIP backend failed with float16 numpy arrays as input. This is fixed by adding a float16 entry to the dtype map. ctypes does not have float16, but it is fine to use another type of the same size so I opted for int16.

Additionally, I have added myself to the Kernel Tuner author list as discussed with Ben.