### PR TITLE
Fix: out-of-date PMTContinuousObserver readings

### DIFF
--- a/kernel_tuner/observers/pmt.py
+++ b/kernel_tuner/observers/pmt.py
@@ -125,9 +125,7 @@ class PMTContinuousObserver(ContinuousObserver):
 
     def get_results(self):
         average_kernel_execution_time_ms = self.results["time"]
-
-        averages = {key: np.average(values) for key, values in self.results.items()}
-        self.parent.initialize_results(self.parent.pm_names)
+        averages = self.parent.get_results()
 
         # correct energy measurement, because current _energy number is collected over the entire duration
         # we estimate energy as the average power over the continuous duration times the kernel execution time


### PR DESCRIPTION
Instead of using the power measurement stored in `self.results`, we should use those in `self.parent.results`. This will ensure we have the latest readings after continuous benchmarking (`benchmark_continuous`), instead of the figures measured during the `benchmark_default` run.