### PR TITLE
Add setup/cleanup functionality to compiler backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- changed HIP python bindings from pyhip-interface to the official hip-python
 
 ## [1.0.0] - 2024-04-04
 - HIP backend to support tuning HIP kernels on AMD GPUs

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -124,31 +124,26 @@ Or you could install Kernel Tuner and PyOpenCL together if you haven't done so a
 
 If this fails, please see the PyOpenCL installation guide (https://wiki.tiker.net/PyOpenCL/Installation)
 
-HIP and PyHIP
+HIP and HIP Python
 -------------
 
-Before we can install PyHIP, you'll need to have the HIP runtime and compiler installed on your system.
+Before we can install HIP Python, you'll need to have the HIP runtime and compiler installed on your system.
 The HIP compiler is included as part of the ROCm software stack. Here is AMD's installation guide:
 
 * `ROCm Documentation: HIP Installation Guide <https://docs.amd.com/bundle/HIP-Installation-Guide-v5.3/page/Introduction_to_HIP_Installation_Guide.html>`__
 
-After you've installed HIP, you will need to install PyHIP. Run the following command in your terminal to install:
+After you've installed HIP, you will need to install HIP Python. Run the following command in your terminal to install:
 
-.. code-block:: bash
+First identify the first three digits of the version number of your ROCm™ installation.
+Then install the HIP Python package(s) as follows:
 
-    pip install pyhip-interface
+.. code-block:: shell
 
-Alternatively, you can install PyHIP from the source code. First, clone the repository from GitHub:
+    python3 -m pip install -i https://test.pypi.org/simple hip-python~=$rocm_version
+    # if you want to install the CUDA Python interoperability package too, run:
+    python3 -m pip install -i https://test.pypi.org/simple hip-python-as-cuda~=$rocm_version
 
-.. code-block:: bash
-
-    git clone https://github.com/jatinx/PyHIP
-
-Then, navigate to the repository directory and run the following command to install:
-
-.. code-block:: bash
-
-    python setup.py install
+For other installation options check `hip-python on GitHub <https://github.com/ROCm/hip-python>`_
 
 Installing the git version
 --------------------------
@@ -171,7 +166,7 @@ The runtime dependencies are:
 
 - `cuda`: install pycuda along with kernel_tuner
 - `opencl`: install pycuda along with kernel_tuner
-- `hip`: install pyhip along with kernel_tuner
+- `hip`: install HIP Python along with kernel_tuner
 - `tutorial`: install packages required to run the guides
 
 These can be installed by appending e.g. ``-E cuda -E opencl -E hip``.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ What Kernel Tuner does:
 
 ## Installation
 
-- First, make sure you have your [CUDA](https://kerneltuner.github.io/kernel_tuner/stable/install.html#cuda-and-pycuda), [OpenCL](https://kerneltuner.github.io/kernel_tuner/stable/install.html#opencl-and-pyopencl), or [HIP](https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-pyhipl) compiler installed
+- First, make sure you have your [CUDA](https://kerneltuner.github.io/kernel_tuner/stable/install.html#cuda-and-pycuda), [OpenCL](https://kerneltuner.github.io/kernel_tuner/stable/install.html#opencl-and-pyopencl), or [HIP](https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-hip-python) compiler installed
 - Then type: `pip install kernel_tuner[cuda]`, `pip install kernel_tuner[opencl]`, or `pip install kernel_tuner[hip]`
 - or why not all of them: `pip install kernel_tuner[cuda,opencl,hip]`
 

--- a/doc/source/backends.rst
+++ b/doc/source/backends.rst
@@ -58,7 +58,7 @@ used to compile the kernels.
   :header: Feature, PyCUDA, CuPy, CUDA-Python, HIP
   :widths: auto
 
-  Python package,      "pycuda", "cupy", "cuda-python", "pyhip-interface"
+  Python package,      "pycuda", "cupy", "cuda-python", "hip-python"
   Selected with lang=, "CUDA", "CUPY", "NVCUDA", "HIP"
   Compiler used,       "nvcc", "nvrtc", "nvrtc", "hiprtc"
 

--- a/doc/source/design.rst
+++ b/doc/source/design.rst
@@ -49,7 +49,7 @@ building blocks for implementing runners.
 The observers are explained in :ref:`observers`.
 
 At the bottom, the backends are shown.
-PyCUDA, CuPy, cuda-python, PyOpenCL and PyHIP are for tuning either CUDA, OpenCL, or HIP kernels.
+PyCUDA, CuPy, cuda-python, PyOpenCL and HIP Python are for tuning either CUDA, OpenCL, or HIP kernels.
 The CompilerFunctions implementation can call any compiler, typically NVCC
 or GCC is used. There is limited support for tuning Fortran kernels.
 This backend was created not just to be able to tune C

--- a/examples/hip/test_vector_add.py
+++ b/examples/hip/test_vector_add.py
@@ -5,11 +5,11 @@ import numpy
 from kernel_tuner import run_kernel
 import pytest
 
-#Check pyhip is installed and if a HIP capable device is present, if not skip the test
+#Check hip is installed and if a HIP capable device is present, if not skip the test
 try:
-    from pyhip import hip, hiprtc
+    from hip import hip, hiprtc
 except ImportError:
-    pytest.skip("PyHIP not installed or PYTHONPATH does not includes PyHIP")
+    pytest.skip("HIP Python not installed or PYTHONPATH does not includes HIP Python")
     hip = None
     hiprtc = None
 

--- a/examples/hip/vector_add.py
+++ b/examples/hip/vector_add.py
@@ -30,8 +30,8 @@ def tune():
     tune_params = OrderedDict()
     tune_params["block_size_x"] = [128+64*i for i in range(15)]
 
-    results, env = tune_kernel("vector_add", kernel_string, size, args, tune_params, lang="HIP", 
-                               cache="vector_add_cache.json", log=logging.DEBUG)
+    results, env = tune_kernel("vector_add", kernel_string, size, args, tune_params, lang="HIP",
+                               log=logging.DEBUG)
 
     # Store the metadata of this run
     store_metadata_file("vector_add-metadata.json")

--- a/kernel_tuner/backends/compiler.py
+++ b/kernel_tuner/backends/compiler.py
@@ -26,6 +26,17 @@ try:
 except ImportError:
     cp = None
 
+try:
+    from jip import hip
+except ImportError:
+    hip = None
+
+try:
+    from hip._util.types import DeviceArray
+except ImportError:
+    Pointer = Exception # using Exception here as a type that will never be among kernel arguments
+    DeviceArray = Exception
+
 
 def is_cupy_array(array):
     """Check if something is a cupy array.
@@ -145,9 +156,9 @@ class CompilerFunctions(CompilerBackend):
         ctype_args = [None for _ in arguments]
 
         for i, arg in enumerate(arguments):
-            if not (isinstance(arg, (np.ndarray, np.number)) or is_cupy_array(arg)):
-                raise TypeError(f"Argument is not numpy or cupy ndarray or numpy scalar but a {type(arg)}")
-            dtype_str = str(arg.dtype)
+            if not (isinstance(arg, (np.ndarray, np.number, DeviceArray)) or is_cupy_array(arg)):
+                raise TypeError(f"Argument is not numpy or cupy ndarray or numpy scalar or HIP Python DeviceArray but a {type(arg)}")
+            dtype_str = arg.typestr if isinstance(arg, DeviceArray) else str(arg.dtype)
             if isinstance(arg, np.ndarray):
                 if dtype_str in dtype_map.keys():
                     # In numpy <= 1.15, ndarray.ctypes.data_as does not itself keep a reference
@@ -156,13 +167,20 @@ class CompilerFunctions(CompilerBackend):
                     # (This changed in numpy > 1.15.)
                     # data_ctypes = data.ctypes.data_as(C.POINTER(dtype_map[dtype_str]))
                     data_ctypes = arg.ctypes.data_as(C.POINTER(dtype_map[dtype_str]))
+                    numpy_arg = arg
                 else:
                     raise TypeError("unknown dtype for ndarray")
             elif isinstance(arg, np.generic):
                 data_ctypes = dtype_map[dtype_str](arg)
+                numpy_arg = arg
             elif is_cupy_array(arg):
                 data_ctypes = C.c_void_p(arg.data.ptr)
-            ctype_args[i] = Argument(numpy=arg, ctypes=data_ctypes)
+                numpy_arg = arg
+            elif isinstance(arg, DeviceArray):
+                data_ctypes = arg.as_c_void_p()
+                numpy_arg = None
+
+            ctype_args[i] = Argument(numpy=numpy_arg, ctypes=data_ctypes)
         return ctype_args
 
     def compile(self, kernel_instance):
@@ -380,6 +398,12 @@ class CompilerFunctions(CompilerBackend):
         :param src: An Argument for some memory allocation
         :type src: Argument
         """
+        # If src.numpy is None, it means we're dealing with a HIP Python DeviceArray
+        if src.numpy is None:
+            # Skip memory copies for HIP Python DeviceArray
+            # This is because DeviceArray manages its own memory and donesn't need
+            # explicit copies like numpy arrays do
+            return
         if isinstance(dest, np.ndarray) and is_cupy_array(src.numpy):
             # Implicit conversion to a NumPy array is not allowed.
             value = src.numpy.get()
@@ -397,6 +421,12 @@ class CompilerFunctions(CompilerBackend):
         :param src: A numpy or cupy array containing the source data
         :type src: np.ndarray or cupy.ndarray
         """
+        # If src.numpy is None, it means we're dealing with a HIP Python DeviceArray
+        if dest.numpy is None:
+            # Skip memory copies for HIP Python DeviceArray
+            # This is because DeviceArray manages its own memory and donesn't need
+            # explicit copies like numpy arrays do
+            return
         if isinstance(dest.numpy, np.ndarray) and is_cupy_array(src):
             # Implicit conversion to a NumPy array is not allowed.
             value = src.get()

--- a/kernel_tuner/backends/compiler.py
+++ b/kernel_tuner/backends/compiler.py
@@ -27,7 +27,7 @@ except ImportError:
     cp = None
 
 try:
-    from jip import hip
+    from hip import hip
 except ImportError:
     hip = None
 

--- a/kernel_tuner/backends/hip.py
+++ b/kernel_tuner/backends/hip.py
@@ -10,7 +10,7 @@ from kernel_tuner.backends.backend import GPUBackend
 from kernel_tuner.observers.hip import HipRuntimeObserver
 
 try:
-    from pyhip import hip, hiprtc
+    from hip import hip, hiprtc
 except (ImportError, RuntimeError):
     hip = None
     hiprtc = None
@@ -32,6 +32,15 @@ dtype_map = {
 
 hipSuccess = 0
 
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
+
 class HipFunctions(GPUBackend):
     """Class that groups the HIP functions on maintains state about the device."""
 
@@ -50,16 +59,18 @@ class HipFunctions(GPUBackend):
         :type iterations: int
         """
         if not hip or not hiprtc:
-            raise ImportError("Unable to import PyHIP, make sure PYTHONPATH includes PyHIP, or check https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-pyhip.")
+            raise ImportError("Unable to import HIP Python, check https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-hip-python.")
 
         # embedded in try block to be able to generate documentation
-        # and run tests without pyhip installed
+        # and run tests without HIP Python installed
         logging.debug("HipFunction instantiated")
 
-        self.hipProps = hip.hipGetDeviceProperties(device)
+        # Get device properties
+        props = hip.hipDeviceProp_t()
+        hip_check(hip.hipGetDeviceProperties(props, device))
 
-        self.name = self.hipProps._name.decode('utf-8')
-        self.max_threads = self.hipProps.maxThreadsPerBlock
+        self.name = props.name.decode('utf-8')
+        self.max_threads = props.maxThreadsPerBlock
         self.device = device
         self.compiler_options = compiler_options or []
         self.iterations = iterations
@@ -70,58 +81,65 @@ class HipFunctions(GPUBackend):
         env["compiler_options"] = compiler_options
         self.env = env
 
-        # create a stream and events
-        self.stream = hip.hipStreamCreate()
-        self.start = hip.hipEventCreate()
-        self.end = hip.hipEventCreate()
+        # Create stream and events 
+        self.stream = hip_check(hip.hipStreamCreate())
+        self.start = hip_check(hip.hipEventCreate())
+        self.end = hip_check(hip.hipEventCreate())
 
-        # default dynamically allocated shared memory size, can be overwritten using smem_args
+        # Default dynamically allocated shared memory size
         self.smem_size = 0
 
         self.current_module = None
 
-        # setup observers
+        # Setup observers
         self.observers = observers or []
         self.observers.append(HipRuntimeObserver(self))
         for obs in self.observers:
             obs.register_device(self)
 
-
     def ready_argument_list(self, arguments):
         """Ready argument list to be passed to the HIP function.
-
         :param arguments: List of arguments to be passed to the HIP function.
             The order should match the argument list on the HIP function.
             Allowed values are np.ndarray, and/or np.int32, np.float32, and so on.
         :type arguments: list(numpy objects)
-
-        :returns: Ctypes structure of arguments to be passed to the HIP function.
-        :rtype: ctypes structure
+        :returns: List of arguments to be passed to the HIP function.
+        :rtype: list
         """
         logging.debug("HipFunction ready_argument_list called")
-
-        ctype_args = []
-        data_ctypes = None
+        prepared_args = []
+        
         for arg in arguments:
             dtype_str = str(arg.dtype)
-            # Allocate space on device for array and convert to ctypes
+            
+            # Handle numpy arrays
             if isinstance(arg, np.ndarray):
                 if dtype_str in dtype_map.keys():
-                    device_ptr = hip.hipMalloc(arg.nbytes)
-                    data_ctypes = arg.ctypes.data_as(ctypes.POINTER(dtype_map[dtype_str]))
-                    hip.hipMemcpy_htod(device_ptr, data_ctypes, arg.nbytes)
-                    # may be part of run_kernel, return allocations here instead
-                    ctype_args.append(device_ptr)
+                    # Allocate device memory
+                    device_ptr = hip_check(hip.hipMalloc(arg.nbytes))
+                    
+                    # Copy data to device using hipMemcpy
+                    hip_check(hip.hipMemcpy(
+                        device_ptr,
+                        arg,
+                        arg.nbytes,
+                        hip.hipMemcpyKind.hipMemcpyHostToDevice
+                    ))
+                    
+                    prepared_args.append(device_ptr)
                 else:
-                    raise TypeError("unknown dtype for ndarray")
-            # Convert valid non-array arguments to ctypes
+                    raise TypeError(f"Unknown dtype {dtype_str} for ndarray")
+                    
+            # Handle numpy scalar types
             elif isinstance(arg, np.generic):
-                data_ctypes = dtype_map[dtype_str](arg)
-                ctype_args.append(data_ctypes)
+                # Convert numpy scalar to corresponding ctypes
+                ctype_arg = dtype_map[dtype_str](arg)
+                prepared_args.append(ctype_arg)
+                
             else:
                 raise ValueError(f"Invalid argument type {type(arg)}, {arg}")
 
-        return ctype_args
+        return prepared_args
 
 
     def compile(self, kernel_instance):
@@ -131,39 +149,58 @@ class HipFunctions(GPUBackend):
             in the parameter space.
         :type kernel_instance: kernel_tuner.core.KernelInstance
 
-        :returns: An ctypes function that can be called directly.
-        :rtype: ctypes._FuncPtr
+        :returns: A HIP kernel function that can be called.
+        :rtype: hipFunction_t
         """
         logging.debug("HipFunction compile called")
 
-        #Format and create program
+        # Format kernel string
         kernel_string = kernel_instance.kernel_string
         kernel_name = kernel_instance.name
         if 'extern "C"' not in kernel_string:
             kernel_string = 'extern "C" {\n' + kernel_string + "\n}"
-        kernel_ptr = hiprtc.hiprtcCreateProgram(kernel_string, kernel_name, [], [])
+        
+        # Create program
+        prog = hip_check(hiprtc.hiprtcCreateProgram(
+            kernel_string.encode(), 
+            kernel_name.encode(), 
+            0, 
+            [], 
+            []
+        ))
 
         try:
-            #Compile based on device (Not yet tested for non-AMD devices)
-            plat = hip.hipGetPlatformName()
-            if plat == "amd":
-                options_list = [f'--offload-arch={self.hipProps.gcnArchName}']
-                options_list.extend(self.compiler_options)
-                hiprtc.hiprtcCompileProgram(kernel_ptr, options_list)
-            else:
-                options_list = []
-                options_list.extend(self.compiler_options)
-                hiprtc.hiprtcCompileProgram(kernel_ptr, options_list)
+            # Get device properties
+            props = hip.hipDeviceProp_t()
+            hip_check(hip.hipGetDeviceProperties(props, 0))
+            
+            # Setup compilation options
+            arch = props.gcnArchName
+            cflags = [b"--offload-arch=" + arch]
+            cflags.extend([opt.encode() if isinstance(opt, str) else opt for opt in self.compiler_options])
 
-            #Get module and kernel from compiled kernel string
-            code = hiprtc.hiprtcGetCode(kernel_ptr)
-            module = hip.hipModuleLoadData(code)
+            # Compile program
+            err, = hiprtc.hiprtcCompileProgram(prog, len(cflags), cflags)
+            if err != hiprtc.hiprtcResult.HIPRTC_SUCCESS:
+                # Get compilation log if there's an error
+                log_size = hip_check(hiprtc.hiprtcGetProgramLogSize(prog))
+                log = bytearray(log_size)
+                hip_check(hiprtc.hiprtcGetProgramLog(prog, log))
+                raise RuntimeError(log.decode())
+
+            # Get compiled code
+            code_size = hip_check(hiprtc.hiprtcGetCodeSize(prog))
+            code = bytearray(code_size)
+            hip_check(hiprtc.hiprtcGetCode(prog, code))
+
+            # Load module and get function
+            module = hip_check(hip.hipModuleLoadData(code))
             self.current_module = module
-            kernel = hip.hipModuleGetFunction(module, kernel_name)
+            kernel = hip_check(hip.hipModuleGetFunction(module, kernel_name.encode()))
 
         except Exception as e:
-            log = hiprtc.hiprtcGetProgramLog(kernel_ptr)
-            print(log)
+            # Cleanup
+            hip_check(hiprtc.hiprtcDestroyProgram(prog.createRef()))
             raise e
 
         return kernel
@@ -171,38 +208,43 @@ class HipFunctions(GPUBackend):
     def start_event(self):
         """Records the event that marks the start of a measurement."""
         logging.debug("HipFunction start_event called")
-
-        hip.hipEventRecord(self.start, self.stream)
+        
+        hip_check(hip.hipEventRecord(self.start, self.stream))
 
     def stop_event(self):
         """Records the event that marks the end of a measurement."""
         logging.debug("HipFunction stop_event called")
-
-        hip.hipEventRecord(self.end, self.stream)
+        
+        hip_check(hip.hipEventRecord(self.end, self.stream))
 
     def kernel_finished(self):
         """Returns True if the kernel has finished, False otherwise."""
         logging.debug("HipFunction kernel_finished called")
-
-        # Query the status of the event
-        return hip.hipEventQuery(self.end)
+        
+        # ROCm HIP returns (hipError_t, bool) for hipEventQuery
+        status = hip.hipEventQuery(self.end)
+        if status[0] == hip.hipError_t.hipSuccess:
+            return True
+        elif status[0] == hip.hipError_t.hipErrorNotReady:
+            return False
+        else:
+            hip_check(status)
 
     def synchronize(self):
         """Halts execution until device has finished its tasks."""
         logging.debug("HipFunction synchronize called")
-
-        hip.hipDeviceSynchronize()
+        
+        hip_check(hip.hipDeviceSynchronize())
 
     def run_kernel(self, func, gpu_args, threads, grid, stream=None):
         """Runs the HIP kernel passed as 'func'.
 
         :param func: A HIP kernel compiled for this specific kernel configuration
-        :type func: ctypes pionter
+        :type func: hipFunction_t
 
-        :param gpu_args: A ctypes structure of arguments to the kernel, order should match the
-            order in the code. Allowed values are either variables in global memory
-            or single values passed by value.
-        :type gpu_args: ctypes structure
+        :param gpu_args: List of arguments to pass to the kernel. Can be DeviceArray 
+                        objects or ctypes values
+        :type gpu_args: list
 
         :param threads: A tuple listing the number of threads in each dimension of
             the thread block
@@ -217,40 +259,38 @@ class HipFunctions(GPUBackend):
         if stream is None:
             stream = self.stream
 
-        # Determine the types of the fields in the structure
-        field_types = [type(x) for x in gpu_args]
+        # Create dim3 objects for grid and block dimensions
+        grid_dim = hip.dim3(x=grid[0], y=grid[1], z=grid[2])
+        block_dim = hip.dim3(x=threads[0], y=threads[1], z=threads[2])
 
-        # Define a new ctypes structure with the inferred layout
-        class ArgListStructure(ctypes.Structure):
-            _fields_ = [(f'field{i}', t) for i, t in enumerate(field_types)]
-            def __getitem__(self, key):
-                return getattr(self, self._fields_[key][0])
-
-        ctype_args = ArgListStructure(*gpu_args)
-
-        hip.hipModuleLaunchKernel(func,
-                                  grid[0], grid[1], grid[2],
-                                  threads[0], threads[1], threads[2],
-                                  self.smem_size,
-                                  stream,
-                                  ctype_args)
+        # Launch kernel with the arguments
+        hip_check(
+            hip.hipModuleLaunchKernel(
+                func,
+                *grid_dim,
+                *block_dim,
+                sharedMemBytes=self.smem_size,
+                stream=stream,
+                kernelParams=None,
+                extra=tuple(gpu_args)
+            )
+        )
 
     def memset(self, allocation, value, size):
         """Set the memory in allocation to the value in value.
 
-        :param allocation: A GPU memory allocation unit
-        :type allocation: ctypes ptr
+        :param allocation: A GPU memory allocation (DeviceArray)
+        :type allocation: DeviceArray or int
 
         :param value: The value to set the memory to
-        :type value: a single 8-bit unsigned int
+        :type value: int (8-bit unsigned)
 
         :param size: The size of to the allocation unit in bytes
         :type size: int
-
         """
         logging.debug("HipFunction memset called")
 
-        hip.hipMemset(allocation, value, size)
+        hip_check(hip.hipMemset(allocation, value, size))
 
     def memcpy_dtoh(self, dest, src):
         """Perform a device to host memory copy.
@@ -259,30 +299,34 @@ class HipFunctions(GPUBackend):
         :type dest: numpy.ndarray
 
         :param src: A GPU memory allocation unit
-        :type src: ctypes ptr
+        :type src: DeviceArray or int
         """
         logging.debug("HipFunction memcpy_dtoh called")
 
-        # Format arguments to correct type and perform memory copy
-        dtype_str = str(dest.dtype)
-        dest_c = dest.ctypes.data_as(ctypes.POINTER(dtype_map[dtype_str]))
-        hip.hipMemcpy_dtoh(dest_c, src, dest.nbytes)
+        hip_check(hip.hipMemcpy(
+            dest,
+            src, 
+            dest.nbytes,
+            hip.hipMemcpyKind.hipMemcpyDeviceToHost
+        ))
 
     def memcpy_htod(self, dest, src):
         """Perform a host to device memory copy.
 
         :param dest: A GPU memory allocation unit
-        :type dest: ctypes ptr
+        :type dest: DeviceArray or int
 
-        :param src: A numpy array in host memory to store the data
+        :param src: A numpy array in host memory to copy from
         :type src: numpy.ndarray
         """
         logging.debug("HipFunction memcpy_htod called")
 
-        # Format arguments to correct type and perform memory copy
-        dtype_str = str(src.dtype)
-        src_c = src.ctypes.data_as(ctypes.POINTER(dtype_map[dtype_str]))
-        hip.hipMemcpy_htod(dest, src_c, src.nbytes)
+        hip_check(hip.hipMemcpy(
+            dest,
+            src,
+            src.nbytes,
+            hip.hipMemcpyKind.hipMemcpyHostToDevice
+        ))
 
     def copy_constant_memory_args(self, cmem_args):
         """Adds constant memory arguments to the most recently compiled module.
@@ -292,19 +336,25 @@ class HipFunctions(GPUBackend):
             string key is used to name the constant memory symbol to which the
             value needs to be copied. Similar to regular arguments, these need
             to be numpy objects, such as numpy.ndarray or numpy.int32, and so on.
-        :type cmem_args: dict( string: numpy.ndarray, ... )
+        :type cmem_args: dict(string: numpy.ndarray, ...)
         """
         logging.debug("HipFunction copy_constant_memory_args called")
 
         # Iterate over dictionary
-        for k, v in cmem_args.items():
-            #Get symbol pointer
-            symbol_ptr, _ = hip.hipModuleGetGlobal(self.current_module, k)
+        for symbol_name, data in cmem_args.items():
+            # Get symbol pointer and size using hipModuleGetGlobal
+            dptr, _ = hip_check(hip.hipModuleGetGlobal(
+                self.current_module,
+                symbol_name.encode()
+            ))
 
-            #Format arguments and perform memory copy
-            dtype_str = str(v.dtype)
-            v_c = v.ctypes.data_as(ctypes.POINTER(dtype_map[dtype_str]))
-            hip.hipMemcpy_htod(symbol_ptr, v_c, v.nbytes)
+            # Copy data to the global memory location
+            hip_check(hip.hipMemcpy(
+                dptr,
+                data,
+                data.nbytes,
+                hip.hipMemcpyKind.hipMemcpyHostToDevice
+            ))
 
     def copy_shared_memory_args(self, smem_args):
         """Add shared memory arguments to the kernel."""

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -616,7 +616,7 @@ class DeviceInterface(object):
                     start_benchmark = time.perf_counter()
 
                     # Run code before benchmarking when using the compiler backend
-                    if "setup_dict" in kernel_options and isinstance(self.dev, CompilerFunctions):
+                    if kernel_options["setup_dict"] and isinstance(self.dev, CompilerFunctions):
                         setup_dict = kernel_options["setup_dict"]
                         args_len = setup_dict["args_len"]
                         kernel_name = kernel_options["kernel_name"]
@@ -632,7 +632,7 @@ class DeviceInterface(object):
                     last_benchmark_time = 1000 * (time.perf_counter() - start_benchmark)
 
                     # Run code after benchmarking when using the compiler backend
-                    if "cleanup_dict" in kernel_options and isinstance(self.dev, CompilerFunctions):
+                    if kernel_options["cleanup_dict"] and isinstance(self.dev, CompilerFunctions):
                         cleanup_dict = kernel_options["cleanup_dict"]
                         args_len = cleanup_dict["args_len"]
                         kernel_name = kernel_options["kernel_name"]

--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -273,6 +273,25 @@ _kernel_options = Options(
                 "dict",
             ),
         ),
+        ("setup_dict", ("""Used only with the Compiler backend, it allows the user to run code before
+                        benchmarking a config. The dictionary should contain:
+                        - 'source': the C/C++ source code to be compiled and executed. 
+                                    Needs to be the same source code as the kernel and cleanup.
+                        - 'args_len': number of arguments to pass from the kernel arguments
+                        - 'kernel_name': name of the setup function in the source
+                        The arguments passed to the setup source are the first 'args_len' arguments
+                        from the kernel arguments list. Any modifications made to these arguments
+                        by the setup code will be visible to the kernel.""", "dict")),
+
+        ("cleanup_dict", ("""Used only with the Compiler backend, it allows the user to run code after
+                        benchmarking a config. The dictionary should contain:
+                        - 'source': the C/C++ source code to be compiled and executed. 
+                                    Needs to be the same source code as the kernel and setup.
+                        - 'args_len': number of arguments to pass from the kernel arguments
+                        - 'kernel_name': name of the cleanup function in the source
+                        The arguments passed to the cleanup source are the first 'args_len' arguments
+                        from the kernel arguments list, which typically include resources allocated
+                        during setup that need to be freed.""", "dict"))
     ]
 )
 
@@ -577,6 +596,8 @@ def tune_kernel(
     observers=None,
     objective=None,
     objective_higher_is_better=None,
+    setup_dict=None,
+    cleanup_dict=None
 ):
     start_overhead_time = perf_counter()
     if log:

--- a/kernel_tuner/observers/hip.py
+++ b/kernel_tuner/observers/hip.py
@@ -3,7 +3,7 @@ import numpy as np
 from kernel_tuner.observers.observer import BenchmarkObserver
 
 try:
-    from pyhip import hip, hiprtc
+    from hip import hip, hiprtc
 except (ImportError, RuntimeError):
     hip = None
     hiprtc = None
@@ -14,7 +14,7 @@ class HipRuntimeObserver(BenchmarkObserver):
 
     def __init__(self, dev):
         if not hip or not hiprtc:
-            raise ImportError("Unable to import PyHIP, make sure PYTHONPATH includes PyHIP, or check https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-pyhip.")
+            raise ImportError("Unable to import HIP Python, or check https://kerneltuner.github.io/kernel_tuner/stable/install.html#hip-and-hip-python.")
 
         self.dev = dev
         self.stream = dev.stream

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -102,6 +102,10 @@ default_block_size_names = [
     "block_size_z",
 ]
 
+try:
+    from hip._util.types import DeviceArray
+except ImportError:
+    DeviceArray = Exception # using Exception here as a type that will never be among kernel arguments
 
 def check_argument_type(dtype, kernel_argument):
     """Check if the numpy.dtype matches the type used in the code."""
@@ -125,16 +129,17 @@ def check_argument_type(dtype, kernel_argument):
         return any([substr in kernel_argument for substr in types_map[dtype]])
     return False  # unknown dtype. do not throw exception to still allow kernel to run.
 
-
 def check_argument_list(kernel_name, kernel_string, args):
-    """Raise an exception if a kernel arguments do not match host arguments."""
+    """Raise an exception if kernel arguments do not match host arguments."""
     kernel_arguments = list()
     collected_errors = list()
+    
     for iterator in re.finditer(kernel_name + "[ \n\t]*" + r"\(", kernel_string):
         kernel_start = iterator.end()
         kernel_end = kernel_string.find(")", kernel_start)
         if kernel_start != 0:
             kernel_arguments.append(kernel_string[kernel_start:kernel_end].split(","))
+
     for arguments_set, arguments in enumerate(kernel_arguments):
         collected_errors.append(list())
         if len(arguments) != len(args):
@@ -142,42 +147,41 @@ def check_argument_list(kernel_name, kernel_string, args):
                 "Kernel and host argument lists do not match in size."
             )
             continue
+
         for i, arg in enumerate(args):
             kernel_argument = arguments[i]
 
-            # Fix to deal with tunable arguments
+            # Handle tunable arguments
             if isinstance(arg, Tunable):
                 continue
-
-            if not isinstance(arg, (np.ndarray, np.generic, cp.ndarray, torch.Tensor)):
+                
+            # Handle numpy arrays and other array types
+            if not isinstance(arg, (np.ndarray, np.generic, cp.ndarray, torch.Tensor, DeviceArray)):
                 raise TypeError(
-                    "Argument at position "
-                    + str(i)
-                    + " of type: "
-                    + str(type(arg))
-                    + " should be of type np.ndarray or numpy scalar"
+                    f"Argument at position {i} of type: {type(arg)} should be of type "
+                    "np.ndarray, numpy scalar, or HIP Python DeviceArray type"
                 )
 
             correct = True
-            if isinstance(arg, np.ndarray) and "*" not in kernel_argument:
-                correct = False  # array is passed to non-pointer kernel argument
+            if isinstance(arg, np.ndarray):
+                if "*" not in kernel_argument:
+                    correct = False
+            
+            if isinstance(arg, DeviceArray):
+                str_dtype = str(np.dtype(arg.typestr))
+            else:
+                str_dtype = str(arg.dtype)
 
-            if correct and check_argument_type(str(arg.dtype), kernel_argument):
+            if correct and check_argument_type(str_dtype, kernel_argument):
                 continue
-
+            
             collected_errors[arguments_set].append(
-                "Argument at position "
-                + str(i)
-                + " of dtype: "
-                + str(arg.dtype)
-                + " does not match "
-                + kernel_argument
-                + "."
+                f"Argument at position {i} of dtype: {str_dtype} does not match {kernel_argument}."
             )
+
         if not collected_errors[arguments_set]:
-            # We assume that if there is a possible list of arguments that matches with the provided one
-            # it is the right one
             return
+
     for errors in collected_errors:
         warnings.warn(errors[0], UserWarning)
 

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -174,12 +174,14 @@ def check_argument_list(kernel_name, kernel_string, args):
 
             if correct and check_argument_type(str_dtype, kernel_argument):
                 continue
-            
+
             collected_errors[arguments_set].append(
                 f"Argument at position {i} of dtype: {str_dtype} does not match {kernel_argument}."
             )
 
         if not collected_errors[arguments_set]:
+            # We assume that if there is a possible list of arguments that matches with the provided one
+            # it is the right one
             return
 
     for errors in collected_errors:

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -12,6 +12,7 @@ import warnings
 from inspect import signature
 from types import FunctionType
 from typing import Optional, Union
+import ctypes as C
 
 import numpy as np
 from constraint import (
@@ -155,12 +156,16 @@ def check_argument_list(kernel_name, kernel_string, args):
             # Handle tunable arguments
             if isinstance(arg, Tunable):
                 continue
+            
+            if isinstance(arg, (C._SimpleCData, C.Array, C._Pointer, type(C.byref(C.c_int())))):
+                continue
 
             # Handle numpy arrays and other array types
-            if not isinstance(arg, (np.ndarray, np.generic, cp.ndarray, torch.Tensor, DeviceArray)):
+            if not isinstance(arg, (np.ndarray, np.generic, cp.ndarray, torch.Tensor, DeviceArray,
+                                    C._SimpleCData, C.Array, C._Pointer, type(C.byref(C.c_int())))):
                 raise TypeError(
                     f"Argument at position {i} of type: {type(arg)} should be of type "
-                    "np.ndarray, numpy scalar, or HIP Python DeviceArray type"
+                    "np.ndarray, numpy scalar, HIP Python DeviceArray type, or ctypes"
                 )
 
             correct = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ pynvml = { version = "^11.4.1", optional = true }
 # OpenCL
 pyopencl = { version = "*", optional = true } # Attention: if pyopencl is changed here, also change `session.install("pyopencl")` in the Noxfile
 # HIP
-pyhip-interface = { version = "*", optional = true }
+hip-python = { version = "*", optional = true }
 # Tutorial (for the notebooks used in the examples)
 jupyter = { version = "^1.0.0", optional = true }
 matplotlib = { version = "^3.5.0", optional = true }
@@ -89,7 +89,7 @@ matplotlib = { version = "^3.5.0", optional = true }
 cuda = ["pycuda", "nvidia-ml-py", "pynvml"]
 opencl = ["pyopencl"]
 cuda_opencl = ["pycuda", "pyopencl"]
-hip = ["pyhip-interface"]
+hip = ["hip-python"]
 tutorial = ["jupyter", "matplotlib", "nvidia-ml-py"]
 
 # ATTENTION: if anything is changed here, run `poetry update` and `poetry export --with docs --without-hashes --format=requirements.txt --output doc/requirements.txt`

--- a/test/context.py
+++ b/test/context.py
@@ -53,15 +53,9 @@ try:
 except Exception:
     cuda_present = False
 
-PYHIP_PATH = os.environ.get("PYHIP_PATH")  # get the PYHIP_PATH environment variable
-try:
-    if PYHIP_PATH is not None:
-        sys.path.insert(0, PYHIP_PATH)
-    from pyhip import hip, hiprtc
-
-    pyhip_present = True
+    hip_present = True
 except ImportError:
-    pyhip_present = False
+    hip_present = False
 
 skip_if_no_pycuda = pytest.mark.skipif(
     not pycuda_present, reason="PyCuda not installed or no CUDA device detected"
@@ -82,7 +76,7 @@ skip_if_no_gfortran = pytest.mark.skipif(
 )
 skip_if_no_openmp = pytest.mark.skipif(not openmp_present, reason="No OpenMP found")
 skip_if_no_openacc = pytest.mark.skipif(not openacc_present, reason="No nvc++ on PATH")
-skip_if_no_pyhip = pytest.mark.skipif(not pyhip_present, reason="No PyHIP found")
+skip_if_no_hip = pytest.mark.skipif(not hip_present, reason="No HIP Python found")
 
 
 def skip_backend(backend: str):
@@ -100,3 +94,5 @@ def skip_backend(backend: str):
         pytest.skip("No gfortran on PATH")
     elif backend.upper() == "OPENACC" and not openacc_present:
         pytest.skip("No nvc++ on PATH")
+    elif backend.upper() == "HIP" and not hip_present:
+        pytest.skip("HIP Python not installed")

--- a/test/context.py
+++ b/test/context.py
@@ -53,6 +53,8 @@ try:
 except Exception:
     cuda_present = False
 
+try:
+    from hip import hip
     hip_present = True
 except ImportError:
     hip_present = False

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -1,10 +1,18 @@
 import json
 
 import pytest
+import ctypes
 from jsonschema import validate
+import numpy as np
+import warnings
+try:
+    from hip import hip
+except:
+    hip = None
 
 from kernel_tuner.file_utils import output_file_schema, store_metadata_file, store_output_file
-from kernel_tuner.util import delete_temp_file
+from kernel_tuner.util import delete_temp_file, check_argument_list
+from .context import skip_if_no_hip
 
 from .test_runners import cache_filename, env, tune_kernel  # noqa: F401
 
@@ -55,3 +63,33 @@ def test_store_metadata_file():
     finally:
         # clean up
         delete_temp_file(filename)
+
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    return result
+
+@skip_if_no_hip
+def test_check_argument_list_device_array():
+    """Test check_argument_list with DeviceArray"""
+    float_kernel = """
+    __global__ void simple_kernel(float* input) {
+        // kernel code
+    }
+    """
+    host_array = np.ones((100,), dtype=np.float32)
+    num_bytes = host_array.size * host_array.itemsize
+    device_array = hip_check(hip.hipMalloc(num_bytes))
+    device_array.configure(
+        typestr="float32",
+        shape=host_array.shape,
+        itemsize=host_array.itemsize
+    )
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        check_argument_list("simple_kernel", float_kernel, [device_array])

--- a/test/test_hip_functions.py
+++ b/test/test_hip_functions.py
@@ -1,5 +1,4 @@
 import ctypes
-
 import numpy as np
 import pytest
 
@@ -7,13 +6,24 @@ from kernel_tuner import tune_kernel
 from kernel_tuner.backends import hip as kt_hip
 from kernel_tuner.core import KernelInstance, KernelSource
 
-from .context import skip_if_no_pyhip
+from .context import skip_if_no_hip
 
 try:
-    from pyhip import hip, hiprtc
+    from hip import hip, hiprtc
     hip_present = True
 except ImportError:
     pass
+
+def hip_check(call_result):
+    err = call_result[0]
+    result = call_result[1:]
+    if len(result) == 1:
+        result = result[0]
+    if isinstance(err, hip.hipError_t) and err != hip.hipError_t.hipSuccess:
+        raise RuntimeError(str(err))
+    elif isinstance(err, hiprtc.hiprtcResult) and err != hiprtc.hiprtcResult.HIPRTC_SUCCESS:
+        raise RuntimeError(str(err))
+    return result
 
 @pytest.fixture
 def env():
@@ -38,9 +48,8 @@ def env():
 
     return ["vector_add", kernel_string, size, args, tune_params]
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_ready_argument_list():
-
     size = 1000
     a = np.int32(75)
     b = np.random.randn(size).astype(np.float32)
@@ -53,14 +62,13 @@ def test_ready_argument_list():
     gpu_args = dev.ready_argument_list(arguments)
 
     # ctypes have no equality defined, so indirect comparison for type and value
-    assert(isinstance(gpu_args[1], ctypes.c_int))
-    assert(isinstance(gpu_args[3], ctypes.c_bool))
-    assert(gpu_args[1] == a)
-    assert(gpu_args[3] == c)
+    assert isinstance(gpu_args[1], ctypes.c_int)
+    assert isinstance(gpu_args[3], ctypes.c_bool)
+    assert gpu_args[1].value == a
+    assert gpu_args[3].value == c
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_compile():
-
     kernel_string = """
     __global__ void vector_add(float *c, float *a, float *b, int n) {
         int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -79,12 +87,11 @@ def test_compile():
     except Exception as e:
         pytest.fail("Did not expect any exception:" + str(e))
 
-
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_memset_and_memcpy_dtoh():
     a = [1, 2, 3, 4]
     x = np.array(a).astype(np.int8)
-    x_d = hip.hipMalloc(x.nbytes)
+    x_d = hip_check(hip.hipMalloc(x.nbytes))
 
     dev = kt_hip.HipFunctions()
     dev.memset(x_d, 4, x.nbytes)
@@ -94,11 +101,11 @@ def test_memset_and_memcpy_dtoh():
 
     assert all(output == np.full(4, 4))
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_memcpy_htod():
     a = [1, 2, 3, 4]
     x = np.array(a).astype(np.float32)
-    x_d = hip.hipMalloc(x.nbytes)
+    x_d = hip_check(hip.hipMalloc(x.nbytes))
     output = np.empty(4, dtype=np.float32)
 
     dev = kt_hip.HipFunctions()
@@ -107,7 +114,7 @@ def test_memcpy_htod():
 
     assert all(output == x)
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_copy_constant_memory_args():
     kernel_string = """
     __constant__ float my_constant_data[100];
@@ -138,13 +145,13 @@ def test_copy_constant_memory_args():
 
     dev.memcpy_dtoh(output, gpu_args[0])
 
-    assert(my_constant_data == output).all()
+    assert (my_constant_data == output).all()
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_smem_args(env):
     result, _ = tune_kernel(*env,
-                            smem_args=dict(size="block_size_x*4"),
-                            verbose=True, lang="HIP")
+                          smem_args=dict(size="block_size_x*4"),
+                          verbose=True, lang="HIP")
     tune_params = env[-1]
     assert len(result) == len(tune_params["block_size_x"])
     result, _ = tune_kernel(
@@ -153,5 +160,3 @@ def test_smem_args(env):
         verbose=True, lang="HIP")
     tune_params = env[-1]
     assert len(result) == len(tune_params["block_size_x"])
-
-

--- a/test/test_observers.py
+++ b/test/test_observers.py
@@ -10,7 +10,7 @@ from .context import (
     skip_if_no_cupy,
     skip_if_no_opencl,
     skip_if_no_pycuda,
-    skip_if_no_pyhip,
+    skip_if_no_hip,
     skip_if_no_pynvml,
 )
 from .test_hip_functions import env as env_hip  # noqa: F401
@@ -68,7 +68,7 @@ def test_register_observer_opencl(env_opencl):
     assert err.errisinstance(NotImplementedError)
     assert "OpenCL" in str(err.value)
 
-@skip_if_no_pyhip
+@skip_if_no_hip
 def test_register_observer_hip(env_hip):
     with raises(NotImplementedError) as err:
         kernel_tuner.tune_kernel(*env_hip, observers=[RegisterObserver()], lang='HIP')


### PR DESCRIPTION
This PR adds setup and cleanup functionality to the compiler backend. When using the compiler backend, users can now provide setup and cleanup code that runs before and after each kernel benchmark. The setup code can allocate and prepare resources that the kernel needs, while the cleanup code ensures proper resource deallocation. This is implemented through two new dictionaries in kernel_options: setup_dict and cleanup_dict, which contain the setup/cleanup source code, function name, and number of arguments to pass from the kernel's argument list. The setup function can modify arguments and these modifications are visible to both the kernel and cleanup functions.