### PR TITLE
Numpy2 support

### DIFF
--- a/kernel_tuner/strategies/bayes_opt.py
+++ b/kernel_tuner/strategies/bayes_opt.py
@@ -235,7 +235,7 @@ class BayesianOptimization:
         self.invalid_value = 1e20
         self.opt_direction = opt_direction
         if opt_direction == "min":
-            self.worst_value = np.PINF
+            self.worst_value = np.inf
             self.argopt = np.argmin
         elif opt_direction == "max":
             self.worst_value = np.NINF
@@ -262,7 +262,7 @@ class BayesianOptimization:
         self.__visited_num = 0
         self.__visited_valid_num = 0
         self.__visited_searchspace_indices = [False] * self.searchspace_size
-        self.__observations = [np.NaN] * self.searchspace_size
+        self.__observations = [np.nan] * self.searchspace_size
         self.__valid_observation_indices = [False] * self.searchspace_size
         self.__valid_params = list()
         self.__valid_observations = list()
@@ -311,7 +311,7 @@ class BayesianOptimization:
 
     def is_valid(self, observation: float) -> bool:
         """Returns whether an observation is valid."""
-        return not (observation is None or observation == self.invalid_value or observation == np.NaN)
+        return not (observation is None or observation == self.invalid_value or observation == np.nan)
 
     def get_af_by_name(self, name: str):
         """Get the basic acquisition functions by their name."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ priority = "explicit"
 # ATTENTION: if anything is changed here, run `poetry update`
 [tool.poetry.dependencies]
 python = ">=3.9,<4"         # <4 is because of hip-python # NOTE when changing the supported Python versions, also change the test versions in the noxfile
-numpy = "^1.26.0"           # Python 3.12 requires numpy at least 1.26
+numpy = "^2.2.4"            # Python 3.12 requires numpy at least 1.26
 scipy = ">=1.11.0"          # held back by Python 3.9
 packaging = "*"             # required by file_utils
 jsonschema = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ priority = "explicit"
 # ATTENTION: if anything is changed here, run `poetry update`
 [tool.poetry.dependencies]
 python = ">=3.9,<4"         # <4 is because of hip-python # NOTE when changing the supported Python versions, also change the test versions in the noxfile
-numpy = "^2.2.4"            # Python 3.12 requires numpy at least 1.26
+numpy = "^2.0.0"            # Python 3.12 requires numpy at least 1.26
 scipy = ">=1.11.0"          # held back by Python 3.9
 packaging = "*"             # required by file_utils
 jsonschema = "*"

--- a/test/context.py
+++ b/test/context.py
@@ -55,8 +55,9 @@ except Exception:
 
 try:
     from hip import hip
+    hip.hipDriverGetVersion()
     hip_present = True
-except ImportError:
+except (ImportError, RuntimeError):
     hip_present = False
 
 skip_if_no_pycuda = pytest.mark.skipif(
@@ -78,7 +79,7 @@ skip_if_no_gfortran = pytest.mark.skipif(
 )
 skip_if_no_openmp = pytest.mark.skipif(not openmp_present, reason="No OpenMP found")
 skip_if_no_openacc = pytest.mark.skipif(not openacc_present, reason="No nvc++ on PATH")
-skip_if_no_hip = pytest.mark.skipif(not hip_present, reason="No HIP Python found")
+skip_if_no_hip = pytest.mark.skipif(not hip_present, reason="No HIP Python found or no HIP device detected")
 
 
 def skip_backend(backend: str):

--- a/test/strategies/test_bayesian_optimization.py
+++ b/test/strategies/test_bayesian_optimization.py
@@ -74,7 +74,7 @@ def test_bo_initialization():
     assert BO.searchspace == pruned_parameter_space
     assert BO.unvisited_cache == pruned_parameter_space
     assert len(BO.observations) == len(pruned_parameter_space)
-    assert BO.current_optimum == np.PINF
+    assert BO.current_optimum == np.inf
 
 def test_bo_initial_sample_lhs():
     sample = BO.draw_latin_hypercube_samples(num_samples=1)


### PR DESCRIPTION
The notebooks for the tutorial (also linked from the Kernel Tuner readme) are broken on Google Colab now because Google Colab automatically imports a Numpy > 2.0. There is no easy workaround unfortunately.

The best solution is to support Numpy >2.0 from Kernel Tuner. Earlier, it was believed the Numpy version was held back by PyCUDA, but I've just tested with Numpy 2.2.4 and PyCUDA 2024.1 and there seems to be no issue. 

As such, I've made a minimal number of changes and we're good to go on supporting Numpy >2.0.