### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -122,7 +122,7 @@ class KernelSource(object):
         The files beyond the first are considered additional files that may also contain tunable parameters
 
         For each file beyond the first this function creates a temporary file with
-        preprocessors statements inserted. Occurences of the original filenames in the
+        preprocessors statements inserted. Occurrences of the original filenames in the
         first file are replaced with their temporary counterparts.
 
         :param kernel_name: A string specifying the kernel name.
@@ -180,7 +180,7 @@ class KernelSource(object):
             temp_file = util.get_temp_filename(suffix="." + f.split(".")[-1])
             temp_files[f] = temp_file
             util.write_file(temp_file, ks)
-            # replace occurences of the additional file's name in the first kernel_string with the name of the temp file
+            # replace occurrences of the additional file's name in the first kernel_string with the name of the temp file
             kernel_string = kernel_string.replace(f, temp_file)
 
         return name, kernel_string, temp_files
@@ -511,7 +511,7 @@ class DeviceInterface(object):
         # run the kernel
         check = self.run_kernel(func, gpu_args, instance)
         if not check:
-            return  # runtime failure occured that should be ignored, skip correctness check
+            return  # runtime failure occurred that should be ignored, skip correctness check
 
         # retrieve gpu results to host memory
         result_host = []
@@ -595,7 +595,7 @@ class DeviceInterface(object):
                     if kernel_options.texmem_args is not None:
                         self.dev.copy_texture_memory_args(kernel_options.texmem_args)
 
-                # stop compilation stopwatch and convert to miliseconds
+                # stop compilation stopwatch and convert to milliseconds
                 last_compilation_time = 1000 * (time.perf_counter() - start_compilation)
 
                 # test kernel for correctness
@@ -628,7 +628,7 @@ class DeviceInterface(object):
                 )
                 raise e
 
-            # clean up any temporary files, if no error occured
+            # clean up any temporary files, if no error occurred
             instance.delete_temp_files()
 
         result["compile_time"] = last_compilation_time or 0
@@ -905,7 +905,7 @@ def _default_verify_function(instance, answer, result_host, atol, verbose):
                     + " detected during correctness check"
                 )
                 print(
-                    "this error occured when checking value of the %oth kernel argument"
+                    "this error occurred when checking value of the %oth kernel argument"
                     % (i,)
                 )
                 print(
@@ -934,7 +934,7 @@ def split_argument_list(argument_list):
         match = re.match(regex, arg, re.S)
         if not match:
             raise ValueError("error parsing templated kernel argument list")
-        type_list.append(re.sub(r"\s+", " ", match.group(1).strip(), re.S))
+        type_list.append(re.sub(r"\s+", " ", match.group(1).strip(), flags=re.S))
         name_list.append(match.group(2).strip())
     return type_list, name_list
 
@@ -956,7 +956,7 @@ def apply_template_typenames(type_list, templated_typenames):
             # if the templated typename occurs as a token in the string, meaning that it is enclosed in
             # beginning of string or whitespace, and end of string, whitespace or star
             regex = r"(^|\s+)(" + k + r")($|\s+|\*)"
-            sub = re.sub(regex, replace_typename_token, arg_type, re.S)
+            sub = re.sub(regex, replace_typename_token, arg_type, flags=re.S)
             type_list[i] = sub
 
 


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+ which you can see in the [CI logs](https://github.com/KernelTuner/kernel_tuner/actions/runs/14495374973/job/40661638564#step:6:466):
```python
test/test_core.py: 20 warnings
  /Users/runner/work/kernel_tuner/kernel_tuner/kernel_tuner/core.py:944: DeprecationWarning: 'count' is passed as positional argument
    type_list.append(re.sub(r"\s+", " ", match.group(1).strip(), re.S))

test/test_core.py: 19 warnings
  /Users/runner/work/kernel_tuner/kernel_tuner/kernel_tuner/core.py:966: DeprecationWarning: 'count' is passed as positional argument
    sub = re.sub(regex, replace_typename_token, arg_type, re.S)
```
It also solves a few typos along the way in the same file.