### PR TITLE
Add support for half and bfloat16 scalars in pyCUDA backend

### DIFF
--- a/kernel_tuner/backends/pycuda.py
+++ b/kernel_tuner/backends/pycuda.py
@@ -180,6 +180,9 @@ class PyCudaFunctions(GPUBackend):
             # pycuda does not support bool, convert to uint8 instead
             elif isinstance(arg, np.bool_):
                 gpu_args.append(arg.astype(np.uint8))
+            # pycuda does not support 16-bit formats, view them as uint16
+            elif isinstance(arg, np.generic) and str(arg.dtype) in ("float16", "bfloat16"):
+                gpu_args.append(arg.view(np.uint16))
             # if not an array, just pass argument along
             else:
                 gpu_args.append(arg)


### PR DESCRIPTION
This PR allows passing 16-bit float as scalars for the pyCUDA backend.