### PR TITLE
add default optimization direction for 'fitness' and 'cost'

### DIFF
--- a/kernel_tuner/integration.py
+++ b/kernel_tuner/integration.py
@@ -11,6 +11,9 @@ from kernel_tuner import util
 objective_default_map = {
     "time": False,
     "energy": False,
+    "fitness": True,
+    "cost": False,
+    "loss": False,
     "GFLOP/s": True,
     "TFLOP/s": True,
     "GB/s": True,


### PR DESCRIPTION
As we extend to more optimization objectives and explore constrained optimization it happens more often that we have a user-defined metric that defines the optimization objective. This pull makes it easy to specify the optimization direction, without the need to explicitly specify the direction using the  ``objective_higher_is_better=`` option of ``tune_kernel()``. Now, if your objective is named ``"fitness"`` Kernel Tuner assumes maximization and for objectives named ``"cost"`` or ``"loss"`` minimization is assumed.