### PR TITLE
use searchspace to check config validity in costfunc

### DIFF
--- a/kernel_tuner/strategies/common.py
+++ b/kernel_tuner/strategies/common.py
@@ -94,9 +94,9 @@ class CostFunc:
 
         # else check if this is a legal (non-restricted) configuration
         if check_restrictions and self.searchspace.restrictions:
-            params_dict = dict(zip(self.searchspace.tune_params.keys(), params))
-            legal = util.check_restrictions(self.searchspace.restrictions, params_dict, self.tuning_options.verbose)
+            legal = self.searchspace.is_param_config_valid(tuple(params))
             if not legal:
+                params_dict = dict(zip(self.searchspace.tune_params.keys(), params))
                 result = params_dict
                 result[self.tuning_options.objective] = util.InvalidConfig()
 


### PR DESCRIPTION
This fixes #326. In particular, this solves the issue that ``util.check_restrictions`` is behind in flexibility and usability compared to the SearchSpace object.