### PR TITLE
Replace bfloat16 dtype from `bfloat16` package by one from `ml_dtypes` package

### DIFF
--- a/kernel_tuner/accuracy.py
+++ b/kernel_tuner/accuracy.py
@@ -59,6 +59,12 @@ class Tunable(UserDict):
 def _find_bfloat16_if_available():
     # Try to get bfloat16 if available.
     try:
+        from ml_dtypes import bfloat16
+        return bfloat16
+    except ImportError:
+        pass
+
+    try:
         from bfloat16 import bfloat16
         return bfloat16
     except ImportError:


### PR DESCRIPTION
This imports the bfloat16 numpy data type from `ml_dtypes` instead of the `bfloat16` package. It seems that the original `bfloat16` package does not seem to work anymore with the latest version of Numpy.

