### PR TITLE
Fix bug in simulated annealing when dealing with negative objectives

### DIFF
--- a/kernel_tuner/strategies/simulated_annealing.py
+++ b/kernel_tuner/strategies/simulated_annealing.py
@@ -104,10 +104,14 @@ def acceptance_prob(old_cost, new_cost, T, tuning_options):
         res = 1.0
     # maybe move if old cost is better than new cost depending on T and random value
     else:
-        if tuning_options.objective_higher_is_better:
-            res = np.exp(((new_cost-old_cost)/new_cost)/T)
-        else:
-            res = np.exp(((old_cost-new_cost)/old_cost)/T)
+        # we must have abs_diff <= 0, as new_cost >= old_cost
+        abs_diff = old_cost - new_cost
+
+        # relative to abs(old_cost), as the cost might be negative
+        rel_diff = abs_diff / np.abs(old_cost)
+
+        # exponential decay
+        res = np.exp(rel_diff / T)
     return res
 
 


### PR DESCRIPTION
Simulated annealing works poorly when the cost is negative, as it takes the difference relative to the old cost (which can be negative). 

This PR makes it take the difference relative to the _absolute_ cost.