### PR TITLE
Remove `error_message_searchspace_fully_observed` message in BO

### DIFF
--- a/kernel_tuner/strategies/bayes_opt.py
+++ b/kernel_tuner/strategies/bayes_opt.py
@@ -268,7 +268,6 @@ class BayesianOptimization:
         self.__valid_observations = list()
         self.unvisited_cache = self.unvisited()
         time_setup = time.perf_counter_ns()
-        self.error_message_searchspace_fully_observed = "The search space has been fully observed"
 
         # take initial sample
         if self.num_initial_samples > 0:
@@ -569,7 +568,7 @@ class BayesianOptimization:
         """Find the next best candidate configuration(s), evaluate those and update the model accordingly."""
         while self.fevals < max_fevals:
             if self.__visited_num >= self.searchspace_size:
-                raise ValueError(self.error_message_searchspace_fully_observed)
+                break
             predictions, _, std = self.predict_list(self.unvisited_cache)
             hyperparam = self.contextual_variance(std)
             list_of_acquisition_values = self.__af(predictions, hyperparam)
@@ -608,7 +607,7 @@ class BayesianOptimization:
             predictions, _, std = self.predict_list(self.unvisited_cache)
             hyperparam = self.contextual_variance(std)
             if self.__visited_num >= self.searchspace_size:
-                raise ValueError(self.error_message_searchspace_fully_observed)
+                break
             time_predictions = time.perf_counter_ns()
             actual_candidate_params = list()
             actual_candidate_indices = list()
@@ -724,7 +723,7 @@ class BayesianOptimization:
             if single_af:
                 return self.__optimize(max_fevals)
             if self.__visited_num >= self.searchspace_size:
-                raise ValueError(self.error_message_searchspace_fully_observed)
+                break
             observations_median = np.median(self.__valid_observations)
             if increase_precision is False:
                 predictions, _, std = self.predict_list(self.unvisited_cache)
@@ -832,7 +831,7 @@ class BayesianOptimization:
             predictions, _, std = self.predict_list(self.unvisited_cache)
             hyperparam = self.contextual_variance(std)
             if self.__visited_num >= self.searchspace_size:
-                raise ValueError(self.error_message_searchspace_fully_observed)
+                break
             for af in aqfs:
                 if self.__visited_num >= self.searchspace_size or self.fevals >= max_fevals:
                     break
@@ -873,7 +872,7 @@ class BayesianOptimization:
             eval_start = time.perf_counter()
             hyperparam = self.contextual_variance(std)
             if self.__visited_num >= self.searchspace_size:
-                raise ValueError(self.error_message_searchspace_fully_observed)
+                break
             for af in aqfs:
                 if self.__visited_num >= self.searchspace_size or self.fevals >= max_fevals:
                     break


### PR DESCRIPTION
Currently, BO throws an exception once it has fully explored the search space. This means it cannot be used for small(er) search spaces, as there is no way to catch this exception and still get the results from Kernel Tuner.

This PR replaces these exception by just breaking from the loop.

@fjwillemsen is this change ok? Could it have any adverse effects?