### PR TITLE
Fix #363: `AttributeError: module 'cupy' has no attribute '_cupyx'`

### DIFF
--- a/kernel_tuner/backends/cupy.py
+++ b/kernel_tuner/backends/cupy.py
@@ -10,8 +10,10 @@ from kernel_tuner.observers.cupy import CupyRuntimeObserver
 # and run tests without cupy installed
 try:
     import cupy as cp
+    import cupyx
 except ImportError:
     cp = None
+    cupyx = None
 
 
 class CupyFunctions(GPUBackend):
@@ -68,7 +70,7 @@ class CupyFunctions(GPUBackend):
 
         # collect environment information
         env = dict()
-        cupy_info = str(cp._cupyx.get_runtime_info()).split("\n")[:-1]
+        cupy_info = str(cupyx.get_runtime_info()).split("\n")[:-1]
         info_dict = {
             s.split(":")[0].strip(): s.split(":")[1].strip() for s in cupy_info
         }

--- a/test/test_cupy_functions.py
+++ b/test/test_cupy_functions.py
@@ -1,4 +1,11 @@
 
+import numpy as np
+
+try:
+    from unittest.mock import patch, Mock, MagicMock
+except ImportError:
+    from mock import patch, Mock, MagicMock
+
 import kernel_tuner
 
 from .context import skip_if_no_cupy
@@ -10,3 +17,25 @@ def test_tune_kernel(env):
     result, _ = kernel_tuner.tune_kernel(*env, lang="cupy", verbose=True)
     assert len(result) > 0
 
+
+@patch('kernel_tuner.backends.cupy.cupyx')
+@patch('kernel_tuner.backends.cupy.cp')
+def test_cupy_init_uses_cupyx_not_private_attr(cp_mock, cupyx_mock):
+    """Regression test: CupyFunctions should use cupyx.get_runtime_info(), not cp._cupyx."""
+    # Setup cp mock
+    dev_mock = MagicMock()
+    dev_mock.attributes = {"MaxThreadsPerBlock": 1024}
+    dev_mock.compute_capability = "75"
+    cp_mock.cuda.Device.return_value = dev_mock
+    cp_mock.cuda.runtime.driverGetVersion.return_value = 11000
+
+    # Setup cupyx mock to return runtime info string
+    runtime_info = "CuPy Version          : 14.0.1\nCUDA Root             : /usr/local/cuda\nDevice 0 Name         : Tesla T4\n"
+    cupyx_mock.get_runtime_info.return_value = runtime_info
+
+    from kernel_tuner.backends.cupy import CupyFunctions
+    dev = CupyFunctions(device=0)
+
+    # Verify cupyx.get_runtime_info() was called, not cp._cupyx.get_runtime_info()
+    cupyx_mock.get_runtime_info.assert_called_once()
+    assert dev.name == "Tesla T4"


### PR DESCRIPTION
Closes #363

## Motivation

`cupy._cupyx` is a private internal attribute that was removed in CuPy 14.x, causing an `AttributeError` on initialization when `CupyFunctions.__init__` called `cp._cupyx.get_runtime_info()` at `kernel_tuner/backends/cupy.py:71`.

## Changes

**`kernel_tuner/backends/cupy.py`**
- Added `import cupyx` alongside `import cupy as cp` in the guarded `try/except ImportError` block (with `cupyx = None` as the fallback), making `cupyx` a proper top-level dependency rather than accessing it through CuPy's private namespace.
- Replaced `cp._cupyx.get_runtime_info()` with `cupyx.get_runtime_info()` on line 71.

**`test/test_cupy_functions.py`**
- Added `test_cupy_init_uses_cupyx_not_private_attr`: patches both `kernel_tuner.backends.cupy.cp` and `kernel_tuner.backends.cupy.cupyx`, constructs a `CupyFunctions(device=0)` instance, and asserts that `cupyx.get_runtime_info()` was called exactly once and that `dev.name` is correctly parsed from the mocked runtime info string. This serves as a regression test to prevent re-introduction of the `_cupyx` private attribute access.

## Testing

The new unit test runs without a physical GPU by mocking both `cp.cuda.Device` and `cupyx.get_runtime_info`. Run it with:

```
pytest test/test_cupy_functions.py::test_cupy_init_uses_cupyx_not_private_attr -v
```

Manually verified on Google Colab with CuPy 14.0.1: `CupyFunctions` initializes without error and `dev.env` is populated correctly.