### PR TITLE
Fix `_find_bfloat16_if_available` always returning `None`

### DIFF
--- a/kernel_tuner/accuracy.py
+++ b/kernel_tuner/accuracy.py
@@ -96,7 +96,7 @@ def _find_bfloat16_if_available():
             + "please install either the package `ml_dtypes`, `jax`, or `tensorflow`"
         )
 
-    return None
+    return dtype
 
 
 def _to_float_dtype(x: str) -> np.dtype:


### PR DESCRIPTION
This fixes an issue where `_find_bfloat16_if_available` always returns `None` instead of the chosen data type.