### PR TITLE
fix for using locked clocks

### DIFF
--- a/kernel_tuner/observers/nvml.py
+++ b/kernel_tuner/observers/nvml.py
@@ -73,19 +73,13 @@ class nvml:
         except pynvml.NVMLError_NotSupported:
             self._auto_boost = None
 
-        # try to initialize application clocks
+        # gather info on clock defaults
         try:
-            if not use_locked_clocks:
-                self.gr_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(
-                    self.dev, pynvml.NVML_CLOCK_GRAPHICS
-                )
-                self.mem_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_MEM)
+            self.gr_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_GRAPHICS)
+            self.mem_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_MEM)
         except pynvml.NVMLError_NotSupported:
             self.gr_clock_default = None
-            self.sm_clock_default = None
             self.mem_clock_default = None
-            self.supported_mem_clocks = []
-            self.supported_gr_clocks = {}
         self.applications_gr_clock = self.gr_clock_default
         self.applications_mem_clock = self.mem_clock_default
 


### PR DESCRIPTION
Using the option use_locked_clocks=True on the NVMLObserver was broken, this should fix it. Have tested it on a system that supports locked clocks but has support for applications clocks deprecated. Planning to test on system with support for application clocks to see if that still works as well.