### PR TITLE
fix issue #362 a second time

### DIFF
--- a/kernel_tuner/strategies/common.py
+++ b/kernel_tuner/strategies/common.py
@@ -199,7 +199,8 @@ class CostFunc:
             # get numerical return value, taking optimization direction into account
             return_value = util.get_result_cost(result,
                 self.tuning_options.objective,
-                self.tuning_options.objective_higher_is_better
+                self.tuning_options.objective_higher_is_better,
+                self.invalid_return_value
             )
 
             if len(return_value) == 1:

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -85,11 +85,11 @@ class NpEncoder(json.JSONEncoder):
         return super(NpEncoder, self).default(obj)
 
 
-def get_result_cost(result: dict, objectives: list[str], objective_higher_is_better: list[bool]) -> list[float]:
+def get_result_cost(result: dict, objectives: list[str], objective_higher_is_better: list[bool], invalid_value) -> list[float]:
     """Returns the cost of a result, taking the objective directions into account."""
     # return the highest cost for invalid results
     if "__error__" in result:
-        return [sys.float_info.max] * len(objectives)
+        return [invalid_value] * len(objectives)
 
     cost_vec = list()
     for objective, is_maximizer in zip(objectives, objective_higher_is_better):

--- a/test/strategies/test_dual_annealing.py
+++ b/test/strategies/test_dual_annealing.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+import kernel_tuner
+
+
+
+def test_dual_annealing_gives_warning(recwarn):
+    """ Uses pytest built-in fixture recwarn to record any warnings this code might throw. """
+
+    kernel_tuner.tune_kernel(
+        kernel_name="foo",
+        kernel_source="void foo(int) { }",
+        problem_size=1,
+        arguments=[np.int32(0)],
+        tune_params={"block_size_x": range(1, 8)},
+        strategy="dual_annealing",
+        restrictions="block_size_x < 4",
+    )
+
+    for warning in recwarn:
+        # Print the actual Warning object / message string
+        print(warning.message)
+
+        # Print the category (e.g., <class 'UserWarning'>)
+        print(warning.category)
+
+        # Print file and line where it was raised
+        print(f"Raised at {warning.filename}:{warning.lineno}")
+
+    # Test that no warnings are thrown
+    assert len(recwarn) == 0
+


### PR DESCRIPTION
Due to a large merge, the issue of a runtime overflow warning in the dual_annealing strategy (issue #362) resurfaced.

This pull fixes the issue by replacing a hard coded sys.float_info.max in the get_result_cost function in util.py with a value passed as an argument. CostFunc is also adjusted to use pass its self.invalid_return_value to the get_result_cost function.

I've also added a test to make sure the issue does not resurface again.